### PR TITLE
Implement benchmarks for retinazer 0.2.0

### DIFF
--- a/artemis-odb-1.0.0/pom.xml
+++ b/artemis-odb-1.0.0/pom.xml
@@ -7,12 +7,12 @@
 		<version>0.1.0-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>artemis-odb-1.0.0-SNAPSHOT-benchmark</artifactId>
+	<artifactId>artemis-odb-1.0.0-benchmark</artifactId>
 	<packaging>jar</packaging>
-	<name>artemis-odb-1.0.0-SNAPSHOT-benchmarks</name>
+	<name>artemis-odb-1.0.0-benchmarks</name>
 
 	<properties>
-		<artemis.version>1.0.0-SNAPSHOT</artemis.version>
+		<artemis.version>1.0.0</artemis.version>
 		<optimizeSystems>false</optimizeSystems>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
 		<module>common</module>
 		<module>ashley-1.0.1</module>
 		<module>ashley-1.6.0</module>
+		<module>retinazer-0.2.0</module>
 		<module>artemis-odb-0.4.0</module>
 		<module>artemis-odb-0.9.0</module>
 		<module>artemis-odb-0.13.1</module>

--- a/retinazer-0.2.0/pom.xml
+++ b/retinazer-0.2.0/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.esfbench</groupId>
+		<artifactId>esf-benchmarks</artifactId>
+		<version>0.1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>retinazer-0.2.0-benchmark</artifactId>
+	<packaging>jar</packaging>
+	<name>retinazer-0.2.0-benchmark</name>
+
+	<properties>
+		<retinazer.version>0.2.0</retinazer.version>
+	</properties>
+
+	<repositories>
+		<repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>bintray-antag99-maven</id>
+			<name>bintray</name>
+			<url>http://dl.bintray.com/antag99/maven</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.github.antag99.retinazer</groupId>
+			<artifactId>retinazer</artifactId>
+			<version>${retinazer.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.esfbench</groupId>
+			<artifactId>common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/retinazer-0.2.0/run-bench.sh
+++ b/retinazer-0.2.0/run-bench.sh
@@ -1,0 +1,1 @@
+java -jar target/microbenchmarks.jar -p entityCount=16384

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/BaselineBenchmark.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/BaselineBenchmark.java
@@ -1,0 +1,31 @@
+package com.github.antag99.retinazer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+
+import com.github.antag99.retinazer.component.PlainPosition;
+import com.github.antag99.retinazer.component.PlainStructComponentA;
+import com.github.antag99.retinazer.system.BaselinePositionSystem;
+import com.github.antag99.retinazer.system.BaselinePositionSystem2;
+import com.github.antag99.retinazer.system.BaselinePositionSystem3;
+import com.github.antag99.retinazer.system.EntityDeleterSystem;
+import com.github.esfbench.JmhSettings;
+
+public class BaselineBenchmark extends JmhSettings {
+    private Engine engine;
+
+    @Setup
+    public void init() {
+        engine = new Engine(new EngineConfig()
+                .addSystem(new BaselinePositionSystem())
+                .addSystem(new BaselinePositionSystem2())
+                .addSystem(new BaselinePositionSystem3())
+                .addSystem(new EntityDeleterSystem(
+                        SEED, entityCount, PlainPosition.class, PlainStructComponentA.class)));
+    }
+
+    @Benchmark
+    public void baseline() {
+        engine.update();
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/InsertRemoveBenchmark.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/InsertRemoveBenchmark.java
@@ -1,0 +1,30 @@
+package com.github.antag99.retinazer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+
+import com.github.antag99.retinazer.system.CompSystemA;
+import com.github.antag99.retinazer.system.CompSystemB;
+import com.github.antag99.retinazer.system.CompSystemC;
+import com.github.antag99.retinazer.system.CompSystemD;
+import com.github.antag99.retinazer.system.EntityManglerSystem;
+import com.github.esfbench.JmhSettings;
+
+public class InsertRemoveBenchmark extends JmhSettings {
+    private Engine engine;
+
+    @Setup
+    public void init() throws Exception {
+        engine = new Engine(new EngineConfig()
+                .addSystem(new EntityManglerSystem(SEED, entityCount, 20))
+                .addSystem(new CompSystemA())
+                .addSystem(new CompSystemB())
+                .addSystem(new CompSystemC())
+                .addSystem(new CompSystemD()));
+    }
+
+    @Benchmark
+    public void insert_remove() {
+        engine.update();
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/PlainComponentBenchmark.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/PlainComponentBenchmark.java
@@ -1,0 +1,31 @@
+package com.github.antag99.retinazer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+
+import com.github.antag99.retinazer.component.PlainPosition;
+import com.github.antag99.retinazer.component.PlainStructComponentA;
+import com.github.antag99.retinazer.system.EntityDeleterSystem;
+import com.github.antag99.retinazer.system.PlainPositionSystem;
+import com.github.antag99.retinazer.system.PlainPositionSystem2;
+import com.github.antag99.retinazer.system.PlainPositionSystem3;
+import com.github.esfbench.JmhSettings;
+
+public class PlainComponentBenchmark extends JmhSettings {
+    private Engine engine;
+
+    @Setup
+    public void init() {
+        engine = new Engine(new EngineConfig()
+                .addSystem(new PlainPositionSystem())
+                .addSystem(new PlainPositionSystem2())
+                .addSystem(new PlainPositionSystem3())
+                .addSystem(new EntityDeleterSystem(
+                        JmhSettings.SEED, entityCount, PlainPosition.class, PlainStructComponentA.class)));
+    }
+
+    @Benchmark
+    public void plain() {
+        engine.update();
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/TransmuterBenchmark.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/TransmuterBenchmark.java
@@ -1,0 +1,28 @@
+package com.github.antag99.retinazer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+
+import com.github.antag99.retinazer.system.BaselinePositionSystem;
+import com.github.antag99.retinazer.system.BaselinePositionSystem2;
+import com.github.antag99.retinazer.system.BaselinePositionSystem3;
+import com.github.antag99.retinazer.system.CompositionManglerSystem;
+import com.github.esfbench.JmhSettings;
+
+public class TransmuterBenchmark extends JmhSettings {
+    private Engine engine;
+
+    @Setup
+    public void init() {
+        engine = new Engine(new EngineConfig()
+                .addSystem(new BaselinePositionSystem())
+                .addSystem(new BaselinePositionSystem2())
+                .addSystem(new BaselinePositionSystem3())
+                .addSystem(new CompositionManglerSystem(SEED, entityCount)));
+    }
+
+    @Benchmark
+    public void entity_edit() {
+        engine.update();
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp0.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp0.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp0 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp1.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp1.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp1 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp2.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp2.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp2 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp3.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp3.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp3 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp4.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp4.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp4 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp5.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp5.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp5 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp6.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp6.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp6 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp7.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp7.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp7 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp8.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp8.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp8 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp9.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/Comp9.java
@@ -1,0 +1,5 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class Comp9 implements Component {}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/PlainPosition.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/PlainPosition.java
@@ -1,0 +1,19 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class PlainPosition implements Component {
+	public float x;
+	public float y;
+
+	public PlainPosition xy(float x, float y) {
+		this.x = x;
+		this.y = y;
+		return this;
+	}
+
+	@Override
+	public String toString() {
+		return "Position [x=" + x + ", y=" + y + "]";
+	}
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/PlainStructComponentA.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/component/PlainStructComponentA.java
@@ -1,0 +1,23 @@
+package com.github.antag99.retinazer.component;
+
+import com.github.antag99.retinazer.Component;
+
+public class PlainStructComponentA implements Component {
+	public float x, y, z;
+	public short something;
+	public boolean flag;
+	
+	public PlainStructComponentA setXyz(float x, float y, float z) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		
+		return this;
+	}
+
+	@Override
+	public String toString() {
+		return "StructComponentA [x=" + x + ", y=" + y + ", z=" + z + ", something=" + something + ", flag=" + flag +
+			"]";
+	}
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/BaselinePositionSystem.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/BaselinePositionSystem.java
@@ -1,0 +1,23 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.PlainPosition;
+
+public class BaselinePositionSystem extends EntityProcessorSystem {
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public BaselinePositionSystem() {
+        super(Family.with(PlainPosition.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        voidness.consume(e);
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/BaselinePositionSystem2.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/BaselinePositionSystem2.java
@@ -1,0 +1,23 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.PlainPosition;
+
+public class BaselinePositionSystem2 extends EntityProcessorSystem {
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public BaselinePositionSystem2() {
+        super(Family.with(PlainPosition.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        voidness.consume(e);
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/BaselinePositionSystem3.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/BaselinePositionSystem3.java
@@ -1,0 +1,23 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.PlainPosition;
+
+public class BaselinePositionSystem3 extends EntityProcessorSystem {
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public BaselinePositionSystem3() {
+        super(Family.with(PlainPosition.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        voidness.consume(e);
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompSystemA.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompSystemA.java
@@ -1,0 +1,25 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.Comp1;
+import com.github.antag99.retinazer.component.Comp4;
+import com.github.antag99.retinazer.component.Comp5;
+
+public class CompSystemA extends EntityProcessorSystem {
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public CompSystemA() {
+        super(Family.with(Comp1.class, Comp4.class, Comp5.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        voidness.consume(e);
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompSystemB.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompSystemB.java
@@ -1,0 +1,25 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.Comp2;
+import com.github.antag99.retinazer.component.Comp8;
+import com.github.antag99.retinazer.component.Comp9;
+
+public class CompSystemB extends EntityProcessorSystem {
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public CompSystemB() {
+        super(Family.with(Comp2.class, Comp8.class, Comp9.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        voidness.consume(e);
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompSystemC.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompSystemC.java
@@ -1,0 +1,26 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.Comp1;
+import com.github.antag99.retinazer.component.Comp2;
+import com.github.antag99.retinazer.component.Comp7;
+import com.github.antag99.retinazer.component.Comp9;
+
+public class CompSystemC extends EntityProcessorSystem {
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public CompSystemC() {
+        super(Family.with(Comp1.class, Comp7.class, Comp9.class).exclude(Comp2.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        voidness.consume(e);
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompSystemD.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompSystemD.java
@@ -1,0 +1,26 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.Comp6;
+import com.github.antag99.retinazer.component.Comp7;
+import com.github.antag99.retinazer.component.Comp8;
+import com.github.antag99.retinazer.component.Comp9;
+
+public class CompSystemD extends EntityProcessorSystem {
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public CompSystemD() {
+        super(Family.with(Comp6.class, Comp7.class, Comp8.class).exclude(Comp9.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        voidness.consume(e);
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompositionManglerSystem.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompositionManglerSystem.java
@@ -1,4 +1,4 @@
-package com.github.antag99.retinazer.system;//
+package com.github.antag99.retinazer.system;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompositionManglerSystem.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/CompositionManglerSystem.java
@@ -1,0 +1,64 @@
+package com.github.antag99.retinazer.system;//
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Random;
+
+import com.github.antag99.retinazer.EntitySystem;
+import com.github.antag99.retinazer.Mapper;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.Wire;
+import com.github.antag99.retinazer.component.PlainPosition;
+
+@SkipWire
+public final class CompositionManglerSystem extends EntitySystem {
+    // NOTE: Ugly, as it depends on ID assignment order, which is not defined
+    // by retinazer. Works with 0.2.0 though.
+
+    int[] ids; // = new int[ENTITY_COUNT];
+
+    private static int ENTITY_COUNT = 0;
+    private static int RENEW = 0;
+
+    private int index;
+
+    private Random rng;
+
+    @Wire
+    Mapper<PlainPosition> positionMapper;
+
+    @SuppressWarnings("unchecked")
+    public CompositionManglerSystem(long seed, int entityCount) {
+        rng = new Random(seed);
+        ENTITY_COUNT = entityCount;
+        RENEW = ENTITY_COUNT / 4;
+
+        ArrayList<Integer> idsList = new ArrayList<Integer>();
+        for (int i = 0; ENTITY_COUNT > i; i++)
+            idsList.add(i);
+        Collections.shuffle(idsList, rng);
+
+        ids = new int[ENTITY_COUNT];
+        for (int i = 0; ids.length > i; i++)
+            ids[i] = idsList.get(i);
+    }
+
+    @Override
+    protected void initialize() {
+        for (int i = 0; ENTITY_COUNT > i; i++)
+            engine.createEntity();
+    }
+
+    @Override
+    protected void update() {
+        for (int i = 0; RENEW > i; i++) {
+            int e = ids[index++];
+            if (positionMapper.has(e)) {
+                positionMapper.remove(e);
+            } else {
+                positionMapper.create(e);
+            }
+            index = index % ENTITY_COUNT;
+        }
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/EntityDeleterSystem.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/EntityDeleterSystem.java
@@ -1,0 +1,64 @@
+package com.github.antag99.retinazer.system;
+
+import java.util.Random;
+
+import com.github.antag99.retinazer.Component;
+import com.github.antag99.retinazer.EntitySystem;
+import com.github.antag99.retinazer.Mapper;
+import com.github.antag99.retinazer.SkipWire;
+
+@SkipWire
+public final class EntityDeleterSystem extends EntitySystem {
+    int[] ids; // = new int[ENTITY_COUNT];
+
+    private static int ENTITY_COUNT = 0;
+
+    int counter;
+    int index;
+
+    private Mapper<?> m1;
+    private Mapper<?> m2;
+
+    private Class<? extends Component> c1;
+    private Class<? extends Component> c2;
+
+    public EntityDeleterSystem(long seed, int entityCount,
+            Class<? extends Component> c1, Class<? extends Component> c2) {
+        this.c1 = c1;
+        this.c2 = c2;
+        Random rng = new Random(seed);
+        ENTITY_COUNT = entityCount;
+        ids = new int[ENTITY_COUNT];
+        for (int i = 0; ids.length > i; i++)
+            ids[i] = (int) (rng.nextFloat() * ENTITY_COUNT);
+    }
+
+    @Override
+    protected void initialize() {
+        this.m1 = engine.getMapper(c1);
+        this.m2 = engine.getMapper(c2);
+
+        for (int i = 0; ENTITY_COUNT > i; i++) {
+            createEntity();
+        }
+    }
+
+    private void createEntity() {
+        int entity = engine.createEntity();
+        m1.create(entity);
+        m2.create(entity);
+    }
+
+    @Override
+    protected void update() {
+        counter++;
+        if (counter == 100) {
+            int e = ids[index++];
+            engine.destroyEntity(e);
+            index = index % ENTITY_COUNT;
+            counter = 0;
+        } else if (counter == 1) { // need to wait one round to reclaim entities
+            createEntity();
+        }
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/EntityManglerSystem.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/EntityManglerSystem.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.Random;
 
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.ObjectSet;
 import com.github.antag99.retinazer.Component;
 import com.github.antag99.retinazer.EntitySystem;
 import com.github.antag99.retinazer.Mapper;
@@ -20,21 +19,42 @@ import com.github.antag99.retinazer.component.Comp7;
 import com.github.antag99.retinazer.component.Comp8;
 import com.github.antag99.retinazer.component.Comp9;
 
-@SkipWire
 public final class EntityManglerSystem extends EntitySystem {
 
+    @SkipWire
     int[] ids; // = new int[ENTITY_COUNT];
+    @SkipWire
     int[] cmp; // = new int[ENTITY_COUNT];
 
+    @SkipWire
     private Array<Class<? extends Component>> types;
 
     private static int ENTITY_COUNT = 0;
     private static int RENEW = 0;
 
+    @SkipWire
     int counter;
+    @SkipWire
     int index;
 
+    @SkipWire
     private Random rng;
+
+    private Mapper<Comp1> mComp1;
+    private Mapper<Comp2> mComp2;
+    private Mapper<Comp3> mComp3;
+    private Mapper<Comp4> mComp4;
+    private Mapper<Comp5> mComp5;
+    private Mapper<Comp6> mComp6;
+    private Mapper<Comp7> mComp7;
+    private Mapper<Comp8> mComp8;
+    private Mapper<Comp9> mComp9;
+
+    @SkipWire
+    int cmpIndex = 0;
+
+    @SkipWire
+    private int[] permutations;
 
     @SuppressWarnings("unchecked")
     // public EntityManglerSystem(long seed, int entityCount, int entityPermutations) {
@@ -53,18 +73,7 @@ public final class EntityManglerSystem extends EntitySystem {
             ids[i] = idsList.get(i);
         // ids[i] = (int)(rng.nextFloat() * ENTITY_COUNT);
 
-        types = new Array<Class<? extends Component>>();
-        types.add(Comp1.class);
-        types.add(Comp2.class);
-        types.add(Comp3.class);
-        types.add(Comp4.class);
-        types.add(Comp5.class);
-        types.add(Comp6.class);
-        types.add(Comp7.class);
-        types.add(Comp8.class);
-        types.add(Comp9.class);
-
-        permutations = new Mapper<?>[entityPermutations][];
+        permutations = new int[entityPermutations];
 
         cmp = new int[ENTITY_COUNT * 4];
         for (int i = 0; cmp.length > i; i++)
@@ -74,12 +83,10 @@ public final class EntityManglerSystem extends EntitySystem {
     @Override
     protected void initialize() {
         for (int i = 0; permutations.length > i; i++) {
-            ObjectSet<Mapper<?>> set = new ObjectSet<>();
+            permutations[i] = 0;
             for (int classIndex = 0, s = (int) (rng.nextFloat() * 7) + 3; s > classIndex; classIndex++) {
-                set.add(engine.getMapper(types.get((int) (rng.nextFloat() * types.size))));
+                permutations[i] |= 1 << (int) (rng.nextFloat() * 9);
             }
-
-            permutations[i] = set.iterator().toArray().toArray(Mapper.class);
         }
 
         for (int i = 0; ENTITY_COUNT > i; i++)
@@ -103,15 +110,27 @@ public final class EntityManglerSystem extends EntitySystem {
         }
     }
 
-    int cmpIndex = 0;
-
-    private Mapper<?>[][] permutations;
-
     private final void createEntity() {
-        Mapper<?>[] mappers = permutations[cmp[cmpIndex++]];
+        int permutation = permutations[cmp[cmpIndex++]];
         int entity = engine.createEntity();
-        for (int i = 0; i < mappers.length; i++)
-            mappers[i].create(entity);
+        if ((permutation & 1) != 0)
+            mComp1.create(entity);
+        if ((permutation & 2) != 0)
+            mComp2.create(entity);
+        if ((permutation & 4) != 0)
+            mComp3.create(entity);
+        if ((permutation & 8) != 0)
+            mComp4.create(entity);
+        if ((permutation & 16) != 0)
+            mComp5.create(entity);
+        if ((permutation & 32) != 0)
+            mComp6.create(entity);
+        if ((permutation & 64) != 0)
+            mComp7.create(entity);
+        if ((permutation & 128) != 0)
+            mComp8.create(entity);
+        if ((permutation & 256) != 0)
+            mComp9.create(entity);
         if (cmpIndex == cmp.length)
             cmpIndex = 0;
     }

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/EntityManglerSystem.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/EntityManglerSystem.java
@@ -1,0 +1,118 @@
+package com.github.antag99.retinazer.system;//
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Random;
+
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectSet;
+import com.github.antag99.retinazer.Component;
+import com.github.antag99.retinazer.EntitySystem;
+import com.github.antag99.retinazer.Mapper;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.Comp1;
+import com.github.antag99.retinazer.component.Comp2;
+import com.github.antag99.retinazer.component.Comp3;
+import com.github.antag99.retinazer.component.Comp4;
+import com.github.antag99.retinazer.component.Comp5;
+import com.github.antag99.retinazer.component.Comp6;
+import com.github.antag99.retinazer.component.Comp7;
+import com.github.antag99.retinazer.component.Comp8;
+import com.github.antag99.retinazer.component.Comp9;
+
+@SkipWire
+public final class EntityManglerSystem extends EntitySystem {
+
+    int[] ids; // = new int[ENTITY_COUNT];
+    int[] cmp; // = new int[ENTITY_COUNT];
+
+    private Array<Class<? extends Component>> types;
+
+    private static int ENTITY_COUNT = 0;
+    private static int RENEW = 0;
+
+    int counter;
+    int index;
+
+    private Random rng;
+
+    @SuppressWarnings("unchecked")
+    // public EntityManglerSystem(long seed, int entityCount, int entityPermutations) {
+    public EntityManglerSystem(long seed, int entityCount, int entityPermutations) {
+        rng = new Random(seed);
+        ENTITY_COUNT = entityCount;
+        RENEW = ENTITY_COUNT / 4;
+
+        ArrayList<Integer> idsList = new ArrayList<Integer>();
+        for (int i = 0; ENTITY_COUNT > i; i++)
+            idsList.add(i);
+        Collections.shuffle(idsList, rng);
+
+        ids = new int[ENTITY_COUNT];
+        for (int i = 0; ids.length > i; i++)
+            ids[i] = idsList.get(i);
+        // ids[i] = (int)(rng.nextFloat() * ENTITY_COUNT);
+
+        types = new Array<Class<? extends Component>>();
+        types.add(Comp1.class);
+        types.add(Comp2.class);
+        types.add(Comp3.class);
+        types.add(Comp4.class);
+        types.add(Comp5.class);
+        types.add(Comp6.class);
+        types.add(Comp7.class);
+        types.add(Comp8.class);
+        types.add(Comp9.class);
+
+        permutations = new Mapper<?>[entityPermutations][];
+
+        cmp = new int[ENTITY_COUNT * 4];
+        for (int i = 0; cmp.length > i; i++)
+            cmp[i] = (int) (rng.nextFloat() * permutations.length);
+    }
+
+    @Override
+    protected void initialize() {
+        for (int i = 0; permutations.length > i; i++) {
+            ObjectSet<Mapper<?>> set = new ObjectSet<>();
+            for (int classIndex = 0, s = (int) (rng.nextFloat() * 7) + 3; s > classIndex; classIndex++) {
+                set.add(engine.getMapper(types.get((int) (rng.nextFloat() * types.size))));
+            }
+
+            permutations[i] = set.iterator().toArray().toArray(Mapper.class);
+        }
+
+        for (int i = 0; ENTITY_COUNT > i; i++)
+            createEntity();
+    }
+
+    @Override
+    protected void update() {
+        counter++;
+
+        if (counter % 2 == 1) {
+            for (int i = 0; RENEW > i; i++) {
+                int e = ids[index++];
+                engine.destroyEntity(e);
+                index = index % ENTITY_COUNT;
+            }
+        } else {
+            for (int i = 0; RENEW > i; i++) {
+                createEntity();
+            }
+        }
+    }
+
+    int cmpIndex = 0;
+
+    private Mapper<?>[][] permutations;
+
+    private final void createEntity() {
+        Mapper<?>[] mappers = permutations[cmp[cmpIndex++]];
+        int entity = engine.createEntity();
+        for (int i = 0; i < mappers.length; i++)
+            mappers[i].create(entity);
+        if (cmpIndex == cmp.length)
+            cmpIndex = 0;
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/PlainPositionSystem.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/PlainPositionSystem.java
@@ -1,0 +1,30 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.Mapper;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.PlainPosition;
+
+public class PlainPositionSystem extends EntityProcessorSystem {
+    Mapper<PlainPosition> positionMapper;
+
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public PlainPositionSystem() {
+        super(Family.with(PlainPosition.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        PlainPosition pos = positionMapper.get(e);
+        pos.x += 1;
+        pos.y -= 1;
+
+        voidness.consume(e);
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/PlainPositionSystem2.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/PlainPositionSystem2.java
@@ -1,0 +1,30 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.Mapper;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.PlainPosition;
+
+public class PlainPositionSystem2 extends EntityProcessorSystem {
+    Mapper<PlainPosition> positionMapper;
+
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public PlainPositionSystem2() {
+        super(Family.with(PlainPosition.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        PlainPosition pos = positionMapper.get(e);
+        pos.x -= 1;
+        pos.y += 1;
+
+        voidness.consume(e);
+    }
+}

--- a/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/PlainPositionSystem3.java
+++ b/retinazer-0.2.0/src/main/java/com/github/antag99/retinazer/system/PlainPositionSystem3.java
@@ -1,0 +1,30 @@
+package com.github.antag99.retinazer.system;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.github.antag99.retinazer.EntityProcessorSystem;
+import com.github.antag99.retinazer.Family;
+import com.github.antag99.retinazer.Mapper;
+import com.github.antag99.retinazer.SkipWire;
+import com.github.antag99.retinazer.component.PlainPosition;
+
+public class PlainPositionSystem3 extends EntityProcessorSystem {
+    Mapper<PlainPosition> positionMapper;
+
+    @SkipWire
+    Blackhole voidness = new Blackhole();
+
+    @SuppressWarnings("unchecked")
+    public PlainPositionSystem3() {
+        super(Family.with(PlainPosition.class));
+    }
+
+    @Override
+    protected void process(int e) {
+        PlainPosition pos = positionMapper.get(e);
+        pos.x += 0.5f;
+        pos.y -= 0.5f;
+
+        voidness.consume(e);
+    }
+}

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -24,6 +24,7 @@ function run_all() {
 	run_bench ashley-1.0.1
 	run_bench ashley-1.6.0
 	run_bench gdx-artemis-0.5.0
+	run_bench retinazer-0.2.0
 
 	# recompiling with bytecode optimizations
 	mvn -Pfast clean install


### PR DESCRIPTION
Implementation of benchmarks for retinazer, copied and adapted from the artemis-odb benchmarks.

Bug report: The other benchmarks do not use the random generator for shuffling id lists, which leads to nondeterministic results.
